### PR TITLE
Convert JioSaavn encrypted URL to actual .mp3 URL

### DIFF
--- a/jio-saavn-api-decryption.js
+++ b/jio-saavn-api-decryption.js
@@ -1,0 +1,38 @@
+/**
+ * Convert JioSaavn encrypted URL to actual .mp3 URL
+ * @author Kinjal Raykarmakar <https://github.com/Kinjalrk2k>
+ */
+
+
+const crypto = require("crypto");
+
+String.prototype.getBytes = function () {
+  var bytes = [];
+  for (var i = 0; i < this.length; ++i) {
+    bytes.push(this.charCodeAt(i));
+  }
+  return bytes;
+};
+
+function decryptURL(encURL) {
+  const des = crypto.createDecipheriv(
+    "des-ecb",
+    Buffer.from("38346591".getBytes()),
+    ""
+  );
+
+  const enc_url = Buffer.from(encURL, "base64");
+  let dec_url = des.update(enc_url, "base64", "utf-8");
+  dec_url = dec_url.replace("_96", "_320.mp4");
+
+  return dec_url;
+}
+
+/**
+ * TESTING
+ */
+const musicURL = decryptURL(
+  "ID2ieOjCrwfgWvL5sXl4B1ImC5QfbsDyt9FOynzequ5IvriekLOmemhlOrNuXjaBrWeCHqaPoit2JaIm/ylxaRw7tS9a8Gtq"
+);
+
+console.log(musicURL);


### PR DESCRIPTION
A simple decryption DES decryption followed by Base64 decoding to convert an encrypted JioSaavn API to an actual .mp3 URL for streaming music